### PR TITLE
fix: specify --install-dir when doing gem install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '${{ matrix.ruby_version }}'
+          bundler-cache: true
       - name: install libyaml
         if: "${{ matrix.os == 'ubuntu-latest' }}"
         run: sudo apt-get install --yes libyaml-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '${{ matrix.ruby_version }}'
+      - name: install libyaml
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        run: sudo apt-get install --yes libyaml-dev
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby_version }}'
           bundler-cache: true
-      - name: install libyaml
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        run: sudo apt-get install --yes libyaml-dev
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,15 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        ruby_version:
+          - '3.1'
+          - '3.2'
+          - '3.3'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '${{ matrix.ruby_version }}'
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -4,9 +4,9 @@ set -Eeuo pipefail
 current_script_path=${BASH_SOURCE[0]}
 bin_dir="$(dirname "${current_script_path}")"
 install_dir="$(dirname "${bin_dir}")"
-gem_home="${install_dir}/gem_home"
+gem_home="${install_dir}/gem"
 
 GEM_HOME="${gem_home}" \
 	GEM_PATH="${gem_home}" \
 	PATH="${gem_home}/bin:${PATH}" \
-	"${gem_home}/bin/bashly" "${@}"
+	bundle exec bashly "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -8,4 +8,5 @@ gem_home="${install_dir}/gem_home"
 
 GEM_HOME="${gem_home}" \
 	GEM_PATH="${gem_home}" \
+	PATH="${gem_home}/bin:${PATH}" \
 	"${gem_home}/bin/bashly" "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -6,8 +6,7 @@ bin_dir="$(dirname "${current_script_path}")"
 install_dir="$(dirname "${bin_dir}")"
 gem_home="${install_dir}/gem"
 
-GEM_HOME="${gem_home}" \
-	GEM_PATH="${gem_home}" \
-	PATH="${gem_home}/bin:${PATH}" \
+PATH="${gem_home}/bin:${PATH}" \
 	BUNDLE_GEMFILE="${install_dir}/Gemfile" \
+	BUNDLE_PATH="${install_dir}/artifacts" \
 	bundle exec bashly "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -6,4 +6,6 @@ bin_dir="$(dirname "${current_script_path}")"
 install_dir="$(dirname "${bin_dir}")"
 gem_home="${install_dir}/gem_home"
 
-GEM_HOME="${gem_home}" "${gem_home}/bin/bashly" "${@}"
+GEM_HOME="${gem_home}" \
+	GEM_PATH="${gem_home}" \
+	"${gem_home}/bin/bashly" "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -9,4 +9,5 @@ gem_home="${install_dir}/gem"
 GEM_HOME="${gem_home}" \
 	GEM_PATH="${gem_home}" \
 	PATH="${gem_home}/bin:${PATH}" \
+	BUNDLE_GEMFILE="${install_dir}/Gemfile" \
 	bundle exec bashly "${@}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,7 +40,9 @@ download_release() {
 	local gem_home="${download_dir}/gem_home"
 	mkdir -p "${gem_home}"
 
-	GEM_HOME="${gem_home}" gem install \
+	GEM_HOME="${gem_home}" \
+		GEM_PATH="${gem_home}" \
+		gem install \
 		--install-dir "${gem_home}" \
 		"${TOOL_NAME}:${version}"
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,6 +41,9 @@ ensure_bundler() {
 }
 
 create_bundle() {
+	local working_dir="${1}"
+	pushd "${working_dir}" &>/dev/null
+
 	ensure_bundler
 	bundle init
 	mkdir -p artifacts
@@ -54,6 +57,8 @@ create_bundle() {
 	# rid of that warning.
 	bundle add fiddle
 	bundle add logger
+
+	popd &>/dev/null
 }
 
 download_release() {
@@ -67,7 +72,7 @@ download_release() {
 	GEM_HOME="${gem_home}" \
 		GEM_PATH="${gem_home}" \
 		PATH="${gem_home}/bin:${PATH}" \
-		create_bundle
+		create_bundle "${download_dir}"
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -43,7 +43,6 @@ download_release() {
 	GEM_HOME="${gem_home}" \
 		GEM_PATH="${gem_home}" \
 		gem install \
-		--install-dir "${gem_home}" \
 		"${TOOL_NAME}:${version}"
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,7 +40,9 @@ download_release() {
 	local gem_home="${download_dir}/gem_home"
 	mkdir -p "${gem_home}"
 
-	GEM_HOME="${gem_home}" gem install "${TOOL_NAME}:${version}"
+	GEM_HOME="${gem_home}" gem install \
+		--install-dir "${gem_home}" \
+		"${TOOL_NAME}:${version}"
 }
 
 install_version() {


### PR DESCRIPTION
on Arch it seems the GEM_HOME env variable isn't good enough (or maybe it's the version of Ruby in the Arch repo...)

in any case, this gets `gem` to install bashly correctly.
