### PR TITLE
fix: use bundler to manage ruby environment

### DIFF
--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -4,9 +4,9 @@ set -Eeuo pipefail
 current_script_path=${BASH_SOURCE[0]}
 bin_dir="$(dirname "${current_script_path}")"
 install_dir="$(dirname "${bin_dir}")"
-gem_home="${install_dir}/gem_home"
+gem_home="${install_dir}/gem"
 
 GEM_HOME="${gem_home}" \
 	GEM_PATH="${gem_home}" \
 	PATH="${gem_home}/bin:${PATH}" \
-	"${gem_home}/bin/bashly" "${@}"
+	bundle exec bashly "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -8,4 +8,5 @@ gem_home="${install_dir}/gem_home"
 
 GEM_HOME="${gem_home}" \
 	GEM_PATH="${gem_home}" \
+	PATH="${gem_home}/bin:${PATH}" \
 	"${gem_home}/bin/bashly" "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -6,8 +6,7 @@ bin_dir="$(dirname "${current_script_path}")"
 install_dir="$(dirname "${bin_dir}")"
 gem_home="${install_dir}/gem"
 
-GEM_HOME="${gem_home}" \
-	GEM_PATH="${gem_home}" \
-	PATH="${gem_home}/bin:${PATH}" \
+PATH="${gem_home}/bin:${PATH}" \
 	BUNDLE_GEMFILE="${install_dir}/Gemfile" \
+	BUNDLE_PATH="${install_dir}/artifacts" \
 	bundle exec bashly "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -6,4 +6,6 @@ bin_dir="$(dirname "${current_script_path}")"
 install_dir="$(dirname "${bin_dir}")"
 gem_home="${install_dir}/gem_home"
 
-GEM_HOME="${gem_home}" "${gem_home}/bin/bashly" "${@}"
+GEM_HOME="${gem_home}" \
+	GEM_PATH="${gem_home}" \
+	"${gem_home}/bin/bashly" "${@}"

--- a/lib/bashly_wrapper.sh
+++ b/lib/bashly_wrapper.sh
@@ -9,4 +9,5 @@ gem_home="${install_dir}/gem"
 GEM_HOME="${gem_home}" \
 	GEM_PATH="${gem_home}" \
 	PATH="${gem_home}/bin:${PATH}" \
+	BUNDLE_GEMFILE="${install_dir}/Gemfile" \
 	bundle exec bashly "${@}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,7 +40,9 @@ download_release() {
 	local gem_home="${download_dir}/gem_home"
 	mkdir -p "${gem_home}"
 
-	GEM_HOME="${gem_home}" gem install \
+	GEM_HOME="${gem_home}" \
+		GEM_PATH="${gem_home}" \
+		gem install \
 		--install-dir "${gem_home}" \
 		"${TOOL_NAME}:${version}"
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,6 +41,9 @@ ensure_bundler() {
 }
 
 create_bundle() {
+	local working_dir="${1}"
+	pushd "${working_dir}" &>/dev/null
+
 	ensure_bundler
 	bundle init
 	mkdir -p artifacts
@@ -54,6 +57,8 @@ create_bundle() {
 	# rid of that warning.
 	bundle add fiddle
 	bundle add logger
+
+	popd &>/dev/null
 }
 
 download_release() {
@@ -67,7 +72,7 @@ download_release() {
 	GEM_HOME="${gem_home}" \
 		GEM_PATH="${gem_home}" \
 		PATH="${gem_home}/bin:${PATH}" \
-		create_bundle
+		create_bundle "${download_dir}"
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -43,7 +43,6 @@ download_release() {
 	GEM_HOME="${gem_home}" \
 		GEM_PATH="${gem_home}" \
 		gem install \
-		--install-dir "${gem_home}" \
 		"${TOOL_NAME}:${version}"
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,7 +40,9 @@ download_release() {
 	local gem_home="${download_dir}/gem_home"
 	mkdir -p "${gem_home}"
 
-	GEM_HOME="${gem_home}" gem install "${TOOL_NAME}:${version}"
+	GEM_HOME="${gem_home}" gem install \
+		--install-dir "${gem_home}" \
+		"${TOOL_NAME}:${version}"
 }
 
 install_version() {


### PR DESCRIPTION
use bundler to create an isolated environment and install dependencies into it

then use it to execute bashly within that environment
